### PR TITLE
Remove unused (and not working) where parameters as they cause the me…

### DIFF
--- a/source/TylerDM.StandardLibrary.Reflection/System/AppDomainExt.cs
+++ b/source/TylerDM.StandardLibrary.Reflection/System/AppDomainExt.cs
@@ -7,28 +7,28 @@ public static class AppDomainExt
 	#endregion
 
 	#region methods
-	public static IEnumerable<Type> GetImplementingTypes<T>(Func<Type, bool>? where = null) =>
-	AppDomain.CurrentDomain.GetImplementingTypes(typeof(T), where);
+	public static IEnumerable<Type> GetImplementingTypes<T>() =>
+	AppDomain.CurrentDomain.GetImplementingTypes(typeof(T));
 
-	public static IEnumerable<Type> GetImplementingTypes(Type type, Func<Type, bool>? where = null) =>
-		AppDomain.CurrentDomain.GetImplementingTypes(type, where);
+	public static IEnumerable<Type> GetImplementingTypes(Type type) =>
+		AppDomain.CurrentDomain.GetImplementingTypes(type);
 
-	public static IEnumerable<Type> GetImplementingTypes<T>(this AppDomain appDomain, Func<Type, bool>? where = null) =>
-		appDomain.GetImplementingTypes(typeof(T), where);
+	public static IEnumerable<Type> GetImplementingTypes<T>(this AppDomain appDomain) =>
+		appDomain.GetImplementingTypes(typeof(T));
 
-	public static IEnumerable<Type> GetImplementingTypes(this AppDomain appDomain, Type type, Func<Type, bool>? where = null) =>
-		appDomain.GetDeveloperTypes(where).Where(x => x.Implements(type));
-
-	/// <summary>
-	/// Returns all the types not created by the compiler.
-	/// </summary>
-	public static IEnumerable<Type> GetDeveloperTypes(Func<Type, bool>? where = null) =>
-		AppDomain.CurrentDomain.GetDeveloperTypes(where);
+	public static IEnumerable<Type> GetImplementingTypes(this AppDomain appDomain, Type type) =>
+		appDomain.GetDeveloperTypes().Where(x => x.Implements(type));
 
 	/// <summary>
 	/// Returns all the types not created by the compiler.
 	/// </summary>
-	public static IEnumerable<Type> GetDeveloperTypes(this AppDomain appDomain, Func<Type, bool>? where = null) =>
+	public static IEnumerable<Type> GetDeveloperTypes() =>
+		AppDomain.CurrentDomain.GetDeveloperTypes();
+
+	/// <summary>
+	/// Returns all the types not created by the compiler.
+	/// </summary>
+	public static IEnumerable<Type> GetDeveloperTypes(this AppDomain appDomain) =>
 		appDomain.getAssemblies().SelectMany(x => x.GetTypes());
 
 	public static bool IsMicrosoft(this Assembly assembly)

--- a/source/TylerDM.StandardLibrary.Reflection/System/AssemblyExt.cs
+++ b/source/TylerDM.StandardLibrary.Reflection/System/AssemblyExt.cs
@@ -7,38 +7,33 @@ public static class AssemblyExt
 	#endregion
 
 	#region methods
-	public static IEnumerable<Type> GetImplementingTypes<T>(Func<Type, bool>? where = null) =>
-		Assembly.GetCallingAssembly().GetImplementingTypes(typeof(T), where);
+	public static IEnumerable<Type> GetImplementingTypes<T>() =>
+		Assembly.GetCallingAssembly().GetImplementingTypes(typeof(T));
 
-	public static IEnumerable<Type> GetImplementingTypes(Type type, Func<Type, bool>? where = null) =>
-		Assembly.GetCallingAssembly().GetImplementingTypes(type, where);
+	public static IEnumerable<Type> GetImplementingTypes(Type type) =>
+		Assembly.GetCallingAssembly().GetImplementingTypes(type);
 
-	public static IEnumerable<Type> GetImplementingTypes<T>(this Assembly assembly, Func<Type, bool>? where = null) =>
-		assembly.GetImplementingTypes(typeof(T), where);
+	public static IEnumerable<Type> GetImplementingTypes<T>(this Assembly assembly) =>
+		assembly.GetImplementingTypes(typeof(T));
 
-	public static IEnumerable<Type> GetImplementingTypes(this Assembly assembly, Type type, Func<Type, bool>? where = null) =>
-		assembly.GetDeveloperTypes(where).Where(x => x.Implements(type));
-
-	/// <summary>
-	/// Returns all the types not created by the compiler.
-	/// </summary>
-	public static IEnumerable<Type> GetDeveloperTypes(Func<Type, bool>? where = null) =>
-		Assembly.GetCallingAssembly().GetDeveloperTypes(where);
+	public static IEnumerable<Type> GetImplementingTypes(this Assembly assembly, Type type) =>
+		assembly.GetDeveloperTypes().Where(x => x.Implements(type));
 
 	/// <summary>
 	/// Returns all the types not created by the compiler.
 	/// </summary>
-	public static IEnumerable<Type> GetDeveloperTypes(this Assembly assembly, Func<Type, bool>? where = null)
-	{
-		var value = _cache.GetOrAdd(
+	public static IEnumerable<Type> GetDeveloperTypes() =>
+		Assembly.GetCallingAssembly().GetDeveloperTypes();
+
+	/// <summary>
+	/// Returns all the types not created by the compiler.
+	/// </summary>
+	public static IEnumerable<Type> GetDeveloperTypes(this Assembly assembly) =>
+		_cache.GetOrAdd(
 			assembly,
 			assembly => assembly.GetTypes()
 				.Where(x => x.IsAnonymous() is false && x.IsCompilerGenerated() is false)
 				.ToArray()
 		);
-		if (where is null) return value;
-
-		return value.Where(where);
-	}
 	#endregion
 }

--- a/source/TylerDM.StandardLibrary.Reflection/TylerDM.StandardLibrary.Reflection.csproj
+++ b/source/TylerDM.StandardLibrary.Reflection/TylerDM.StandardLibrary.Reflection.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 		<IsPackable>true</IsPackable>
-		<Version>1.2.1</Version>
+		<Version>1.2.2</Version>
 		<RepositoryType>Git</RepositoryType>
 		<NeutralLanguage>en-US</NeutralLanguage>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>


### PR DESCRIPTION
…thods to do more than one conceptual task at a time.